### PR TITLE
modernize the population

### DIFF
--- a/src/main/java/com/kryptnostic/rhizome/configuration/amazon/AmazonLaunchConfiguration.java
+++ b/src/main/java/com/kryptnostic/rhizome/configuration/amazon/AmazonLaunchConfiguration.java
@@ -23,7 +23,8 @@ package com.kryptnostic.rhizome.configuration.amazon;
 
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
+
+import java.util.Optional;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;

--- a/src/main/java/com/kryptnostic/rhizome/configuration/amazon/AwsLaunchConfiguration.java
+++ b/src/main/java/com/kryptnostic/rhizome/configuration/amazon/AwsLaunchConfiguration.java
@@ -23,18 +23,19 @@ package com.kryptnostic.rhizome.configuration.amazon;
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Optional;
+
 public class AwsLaunchConfiguration implements AmazonLaunchConfiguration {
-    public static final  String BUCKET_FIELD   = "bucket";
-    public static final  String FOLDER_FIELD   = "folder";
-    public static final  String REGION_FIELD   = "region";
-    private static final String DEFAULT_FOLDER = "";
-    private final String            bucket;
-    private final String            folder;
-    private final Optional<Regions> region;
+    public static final  String                      BUCKET_FIELD   = "bucket";
+    public static final  String                      FOLDER_FIELD   = "folder";
+    public static final  String                      REGION_FIELD   = "region";
+    private static final String                      DEFAULT_FOLDER = "";
+    private final        String                      bucket;
+    private final        String                      folder;
+    private final        Optional<Regions> region;
 
     @JsonCreator
     public AwsLaunchConfiguration(
@@ -44,7 +45,7 @@ public class AwsLaunchConfiguration implements AmazonLaunchConfiguration {
         Preconditions.checkArgument( StringUtils.isNotBlank( bucket ),
                 "S3 bucket for configuration must be specified." );
         this.bucket = bucket;
-        String rawFolder = folder.or( DEFAULT_FOLDER );
+        String rawFolder = folder.orElse( DEFAULT_FOLDER );
 
         while ( StringUtils.endsWith( rawFolder, "/" ) ) {
             StringUtils.removeEnd( rawFolder, "/" );
@@ -56,12 +57,12 @@ public class AwsLaunchConfiguration implements AmazonLaunchConfiguration {
             this.folder = rawFolder;
         }
 
-        this.region = region.isPresent() ? Optional.of( Regions.fromName( region.get() ) ) : Optional.absent();
+        this.region = region.map( Regions::fromName );
     }
 
     @Override
     @JsonProperty( REGION_FIELD )
-    public Optional<Regions> getRegion() {
+    public java.util.Optional<Regions> getRegion() {
         return region;
     }
 

--- a/src/main/java/com/kryptnostic/rhizome/configuration/amazon/AwsLaunchConfiguration.java
+++ b/src/main/java/com/kryptnostic/rhizome/configuration/amazon/AwsLaunchConfiguration.java
@@ -62,7 +62,7 @@ public class AwsLaunchConfiguration implements AmazonLaunchConfiguration {
 
     @Override
     @JsonProperty( REGION_FIELD )
-    public java.util.Optional<Regions> getRegion() {
+    public Optional<Regions> getRegion() {
         return region;
     }
 

--- a/src/main/java/com/openlattice/ResourceConfigurationLoader.java
+++ b/src/main/java/com/openlattice/ResourceConfigurationLoader.java
@@ -1,9 +1,6 @@
 package com.openlattice;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.dataloom.mappers.ObjectMappers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;

--- a/src/main/java/com/openlattice/authentication/Auth0Configuration.java
+++ b/src/main/java/com/openlattice/authentication/Auth0Configuration.java
@@ -23,12 +23,10 @@ package com.openlattice.authentication;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.LoadingCache;
 import com.kryptnostic.rhizome.configuration.annotation.ReloadableConfiguration;
 import java.io.Serializable;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**

--- a/src/main/java/com/openlattice/retrofit/RhizomeByteConverterFactory.java
+++ b/src/main/java/com/openlattice/retrofit/RhizomeByteConverterFactory.java
@@ -22,7 +22,7 @@ public class RhizomeByteConverterFactory extends Converter.Factory {
             Annotation[] annotations,
             Retrofit retrofit ) {
         if ( isByteArray( type ) ) {
-            return responseBody -> responseBody.bytes();
+            return ResponseBody::bytes;
         }
         return null;
     }

--- a/src/main/java/com/openlattice/retrofit/RhizomeJacksonConverterFactory.java
+++ b/src/main/java/com/openlattice/retrofit/RhizomeJacksonConverterFactory.java
@@ -1,9 +1,7 @@
 package com.openlattice.retrofit;
 
 import com.dataloom.mappers.ObjectMappers;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -14,9 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Charsets;
 
 import okhttp3.MediaType;


### PR DESCRIPTION
This PR:
- Fixes a bunch of mechanical warnings
- Removing unused imports
- Removing unnecessary boxing/unboxing
- Uses singletonList for one-element lists
- Uses Java classes instead of Guava for functional constructs
- Fixes compiler warnings for upgrading from Java 5 through Java 8