### PR TITLE
LATTICE-61 configuration service should load from aws

### DIFF
--- a/src/main/java/com/openlattice/ResourceConfigurationLoader.java
+++ b/src/main/java/com/openlattice/ResourceConfigurationLoader.java
@@ -11,9 +11,11 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 
 /**
  * Created by mtamayo on 7/3/17.
@@ -68,6 +70,18 @@ public class ResourceConfigurationLoader {
         } else {
             return null;
         }
+    }
+
+    public static <T> T loadConfigurationFromFile( String path, Class<T> clazz ) {
+        T s = null;
+        try {
+            Path p = Path.of(path, getReloadableConfigurationUri( clazz ));
+            File f = p.toFile();
+            s = mapper.readValue( f, clazz );
+        } catch ( IOException e ) {
+            logger.error( "Failed to load configuration from {} for {}: {}", path, clazz, e );
+        }
+        return s;
     }
 
     public static <T> T loadConfigurationFromResource( String uri, Class<T> clazz ) {


### PR DESCRIPTION
Put configuration loader behind an interface that abstracts away
different config sources.

Also adds a configuration profile for running in a container and
loading from a fixed volume path, rather than from classpath.